### PR TITLE
fix: add presence check for childResourceType

### DIFF
--- a/packages/app/components/resource/ResourceInstanceValueFormInput.vue
+++ b/packages/app/components/resource/ResourceInstanceValueFormInput.vue
@@ -328,7 +328,7 @@ function setAllTo(value: any) {
         </template>
 
         <ResourceInstanceValueNestedForm
-          v-else
+          v-else-if="childResourceType"
           :model-value="modelValue"
           :field="field"
           :resource-type="resourceType"


### PR DESCRIPTION
Solves #4 

This PR resolves an issue where sometimes navigating within the GUI causes a blocking error with .fields being undefined. I'm not sure if this is fixing the issue itself or a side effect of the issue. 

Note that Typescript is also complaining at this exact spot if you run it without the fix.

## How to run locally ?

1. Clone moquerie on your machine for example at `/home/user/Projects/github.com/project-name/moquerie/`
2. Build moquerie : `pnpm run build`
3. In the project where moquerie is being used update the scripts section in packages.json as follows to point towards your fork

```
scripts: {
    "dev:mock": "node /home/user/Projects/github.com/project-name/moquerie/packages/moquerie/bin.mjs",
    ...
 }
```